### PR TITLE
Update for Topping DX7s

### DIFF
--- a/patches/4.9.65/usb-quirks.patch
+++ b/patches/4.9.65/usb-quirks.patch
@@ -63,6 +63,7 @@ index 7613b9e..4a8fc40 100644
 +	case USB_ID(0x20b1, 0x3036): /* Holo Springs Level 3 R2R DAC */
 +	case USB_ID(0x20b1, 0x300f): /* Engineered Electronics Stereo Playback Interface */
 +	case USB_ID(0x20b1, 0x3021): /* Eastern El. MiniMax Tube DAC Supreme */
++ case USB_ID(0x152a, 0x8750): /* Topping DX7s */
 +                if (fp->altsetting == 3)
 +                        return SNDRV_PCM_FMTBIT_DSD_U32_BE;
 +                break;


### PR DESCRIPTION
Bus 001 Device 004: ID 152a:8750 Thesycon Systemsoftware & Consulting GmbH

Topping DX7s at usb-3f980000.usb-1.1.2, high speed : USB Audio
Playback:
  Status: Stop
  Interface 1
    Altset 1
    Format: S32_LE
    Channels: 2
    Endpoint: 1 OUT (ASYNC)
    Rates: 44100, 48000, 88200, 96000, 176400, 192000, 352800, 384000, 705600, 7                                                                                                                                                             68000
    Data packet interval: 125 us
  Interface 1
    Altset 2
    Format: S32_LE
    Channels: 2
    Endpoint: 1 OUT (ASYNC)
    Rates: 44100, 48000, 88200, 96000, 176400, 192000, 352800, 384000, 705600, 7                                                                                                                                                             68000
    Data packet interval: 125 us
  Interface 1
    Altset 3
    Format: SPECIAL
    Channels: 2
    Endpoint: 1 OUT (ASYNC)
    Rates: 44100, 48000, 88200, 96000, 176400, 192000, 352800, 384000, 705600, 7                                                                                                                                                             68000
    Data packet interval: 125 us